### PR TITLE
fix XtraBackup SST configuration documentation

### DIFF
--- a/docs/manual/xtrabackup_sst.md
+++ b/docs/manual/xtrabackup_sst.md
@@ -232,14 +232,14 @@ cpat='.*galera\.cache$\|.*sst_in_progress$\|.*grastate\.dat$\|.*\.err$\|.*\.log$
 | Parameter      | Description        |
 | -------------- | ------------------ |
 | Default:        | not set (disabled)               |
-| Example:       | compressor=’zstd -TO -2’                  |
+| Example:       | compressor=’zstd -T0 -2’                  |
 
 ### decompressor
 
 | Parameter      | Description        |
 | -------------- | ------------------ |
 | Default:        | not set (disabled)               |
-| Example:       | decompressor=’zstd -TO -dc’                  |
+| Example:       | decompressor=’zstd -T0 -dc’                  |
 
 Stream-based compression and decompression are performed on the stream, in contrast to performing decompression after streaming to disk, which involves additional I/O. The savings are considerable, up to half the I/O on the JOINER node.
 


### PR DESCRIPTION
The examples for `compressor` and `decompressor` use zstd which was given with a wrong parameter. The `-T#` param of zstd for defining the number of compression threads to spawn requires a number. In the example, it used an uppercase 'o'. 

Let's hope I can save other people from copy&pasting and tripping over this little error and prevent their cluster from crashing on the next SST... 🙈 