### PR TITLE
DOCS-44-test Test dynamic date (8.0)

### DIFF
--- a/mkdocs-base.yml
+++ b/mkdocs-base.yml
@@ -57,10 +57,6 @@ extra_css:
   - css/design.css
   - css/extra.css
 
-#Copyright
-copyright: >
-  "<a href='https://www.percona.com/about'>Percona LLC</a> and/or its affiliates &copy; <script>document.write(new Date().getFullYear())</script> — <a href='#__consent'>Cookie Consent</a>"
-
 extra_javascript:
   - js/version-select.js
   - js/promptremover.js


### PR DESCRIPTION
Since we have copyright configured in two places, the one in mkdocs-base.yml is not required. The config in copyright.html already uses the dynamic date, so I've removed the config from mkdocs-base.yml.

modified:   mkdocs-base.yml