### PR TITLE
remove deprecated options from mysql config template

### DIFF
--- a/docs/apt.md
+++ b/docs/apt.md
@@ -69,7 +69,7 @@ We gather [Telemetry data] in the Percona packages and Docker images.
 6. Enable the `release` repository for *Percona XtraDB Cluster*:
 
     ```shell
-    sudo percona-release setup pxc80
+    sudo percona-release setup pxc84-lts
     ```
 
 7. Install the cluster:

--- a/docs/configure-cluster-rhel.md
+++ b/docs/configure-cluster-rhel.md
@@ -60,9 +60,6 @@ on the first node (`percona1`) contains the following:
     # Cluster connection URL contains the IPs of node#1, node#2 and node#3
     wsrep_cluster_address=gcomm://192.168.70.71,192.168.70.72,192.168.70.73
 
-    # In order for Galera to work correctly binlog format should be ROW
-    binlog_format=ROW
-
     # Using the MyISAM storage engine is not recommended.
     default_storage_engine=InnoDB
 
@@ -156,9 +153,6 @@ on the first node (`percona1`) contains the following:
     # Cluster connection URL contains IPs of node#1, node#2 and node#3
     wsrep_cluster_address=gcomm://192.168.70.71,192.168.70.72,192.168.70.73
 
-    # In order for Galera to work correctly binlog format should be ROW
-    binlog_format=ROW
-
     # Using the MyISAM storage engine is not recommended
     default_storage_engine=InnoDB
 
@@ -226,9 +220,6 @@ on the first node (`percona1`) contains the following:
 
     # Cluster connection URL contains IPs of node#1, node#2 and node#3
     wsrep_cluster_address=gcomm://192.168.70.71,192.168.70.72,192.168.70.73
-
-    # In order for Galera to work correctly binlog format should be ROW
-    binlog_format=ROW
 
     # Using the MyISAM storage engine is not recommended
     default_storage_engine=InnoDB

--- a/docs/configure-cluster-ubuntu.md
+++ b/docs/configure-cluster-ubuntu.md
@@ -64,9 +64,6 @@ for the first node (`pxc1`) contains the following:
     # Cluster connection URL contains the IPs of node#1, node#2 and node#3
     wsrep_cluster_address=gcomm://192.168.70.61,192.168.70.62,192.168.70.63
 
-    # In order for Galera to work correctly binlog format should be ROW
-    binlog_format=ROW
-
     # Using the MyISAM storage engine is not recommended
     default_storage_engine=InnoDB
 
@@ -152,9 +149,6 @@ on the second node (`pxc2`) contains the following:
     # Cluster connection URL contains IPs of node#1, node#2 and node#3
     wsrep_cluster_address=gcomm://192.168.70.61,192.168.70.62,192.168.70.63
 
-    # In order for Galera to work correctly binlog format should be ROW
-    binlog_format=ROW
-
     # Using the MyISAM storage engine is not recommended
     default_storage_engine=InnoDB
 
@@ -224,9 +218,6 @@ on the third node (`pxc3`) contains the following:
 
     # Cluster connection URL contains IPs of node#1, node#2 and node#3
     wsrep_cluster_address=gcomm://192.168.70.61,192.168.70.62,192.168.70.63
-
-    # In order for Galera to work correctly binlog format should be ROW
-    binlog_format=ROW
 
     # Using the MyISAM storage engine is not recommended
     default_storage_engine=InnoDB

--- a/docs/configure-nodes.md
+++ b/docs/configure-nodes.md
@@ -110,10 +110,8 @@ wsrep_provider=/usr/lib64/galera4/libgalera_smm.so
 #If no IP is found, this implies that a new cluster needs to be created,
 #in order to do that you need to bootstrap this node
 wsrep_cluster_address=gcomm://
-# In order for Galera to work correctly binlog format should be ROW
-binlog_format=ROW
 # Slave thread to use
-wsrep_slave_threads=8
+wsrep_applier_threads=8
 wsrep_log_conflicts
 # This changes how InnoDB autoincrement locks are managed and is a requirement for Galera
 innodb_autoinc_lock_mode=2
@@ -181,10 +179,6 @@ This method requires a user for SST to be set up on the initial node.
 [`pxc_strict_mode`](wsrep-system-index.md#pxc_strict_mode)
 
 [PXC Strict Mode](strict-mode.md#pxc-strict-mode) is enabled by default and set to `ENFORCING`, which blocks the use of tech preview features and unsupported features in Percona XtraDB Cluster.
-
-[`binlog_format`](https://dev.mysql.com/doc/refman/{{vers}}/en/replication-options-binary-log.html#sysvar_binlog_format)
-
-Galera supports only row-level replication, so set `binlog_format=ROW`.
 
 [`default_storage_engine`](https://dev.mysql.com/doc/refman/{{vers}}/en/server-system-variables.html#sysvar_default_storage_engine)
 

--- a/docs/set-up-3nodes-ec2.md
+++ b/docs/set-up-3nodes-ec2.md
@@ -69,8 +69,6 @@ To set up Percona XtraDB Cluster:
     datadir=/mnt/data
     user=mysql
 
-    binlog_format=ROW
-
     wsrep_provider=/usr/lib64/libgalera_smm.so
     wsrep_cluster_address=gcomm://10.93.46.58,10.93.46.59,10.93.46.60
 

--- a/docs/singlebox.md
+++ b/docs/singlebox.md
@@ -24,7 +24,6 @@ To set up the cluster:
     basedir=/usr/local/Percona-XtraDB-Cluster-8.0.x86_64
     user=mysql
     log_error=error.log
-    binlog_format=ROW
     wsrep_cluster_address='gcomm://192.168.2.21:5030,192.168.2.21:6030'
     wsrep_provider=/usr/local/Percona-XtraDB-Cluster-8.0.x86_64/lib/libgalera_smm.so
     wsrep_sst_receive_address=192.168.2.21:4020
@@ -46,7 +45,6 @@ To set up the cluster:
     basedir=/usr/local/Percona-XtraDB-Cluster-8.0.x86_64
     user=mysql
     log_error=error.log
-    binlog_format=ROW
     wsrep_cluster_address='gcomm://192.168.2.21:4030,192.168.2.21:6030'
     wsrep_provider=/usr/local/Percona-XtraDB-Cluster-8.0.x86_64/lib/libgalera_smm.so
     wsrep_sst_receive_address=192.168.2.21:5020
@@ -69,7 +67,6 @@ To set up the cluster:
     basedir=/usr/local/Percona-XtraDB-Cluster-8.0.x86_64
     user=mysql
     log_error=error.log
-    binlog_format=ROW
     wsrep_cluster_address='gcomm://192.168.2.21:4030,192.168.2.21:5030'
     wsrep_provider=/usr/local/Percona-XtraDB-Cluster-8.0.x86_64/lib/libgalera_smm.so
     wsrep_sst_receive_address=192.168.2.21:6020

--- a/docs/strict-mode.md
+++ b/docs/strict-mode.md
@@ -195,12 +195,6 @@ At runtime, any attempt to change [`wsrep_replicate_myisam`](wsrep-system-index.
 
     The [`wsrep_replicate_myisam`](wsrep-system-index.md#wsrep_replicate_myisam) variable controls *replication* for MyISAM tables, and this validation only checks whether it is allowed. Undesirable operations for MyISAM tables are restricted using the Storage engine validation.
 
-### Binary log format
-
-Percona XtraDB Cluster supports only the default row-based binary logging format.  In
-{{vers}}, setting the [binlog_format](https://dev.mysql.com/doc/refman/{{vers}}/en/replication-options-binary-log.html#sysvar_binlog_format) variable to anything but
-`ROW` at startup or runtime is not allowed regardless of the value of the `pxc_strict_mode` variable.
-
 ### Tables without primary keys
 
 Percona XtraDB Cluster cannot properly propagate certain write operations

--- a/docs/wsrep-system-index.md
+++ b/docs/wsrep-system-index.md
@@ -114,8 +114,6 @@ or the node is bootstrapping, then [`pxc_strict_mode`](wsrep-system-index.md#pxc
      
      * `wsrep_replicate_myisam=OFF`
      
-     * `binlog_format=ROW`
-     
      * `log_output=FILE` or `log_output=NONE` or `log_output=FILE,NONE`
      
     The `SERIALIZABLE` method of isolation is not allowed in `ENFORCING` mode.


### PR DESCRIPTION
remove binlog_format from mysql template as this Option is deprecated and subject to removal: https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html#sysvar_binlog_format
https://galeracluster.com/2024/07/galera-cluster-for-mysql-8-0-37-26-19-released/

Replace wsrep_slave_threads with wsrep_applier_threads as Slave naming schema is deprecated:
https://galeracluster.com/library/documentation/mysql-wsrep-options.html#wsrep-slave-threads

Update "percona-release setup" command in apt.md for pxc-docs 8.4 as it would initialize pxc80 repo instead of pxc84-lts.